### PR TITLE
Add flowforge-team-library store plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 A Node-RED Storage Plugin for the FlowForge platform.
 
-This plugin provides a complete `storageModule` configuration to tie a Node-RED instance to the FlowForge platform.
+This plugin provides:
+ - a complete `storageModule` configuration to tie a Node-RED instance to the FlowForge platform.
+ - a Library Store plugin that supports team-wide shared libraries in the editor
 
-### Configuration
+### Storage Module configuration
+
 ```
 storageModule: require('@flowforge/nr-storage'),
 httpStorage:{
@@ -17,3 +20,25 @@ httpStorage:{
  - `projectID` - is the UUID of the project
  - `baseURL` - the root URL for the FlowForge Storage API
  - `token` - authentication token
+
+
+### Library Store Plugin configuration
+
+```
+editorTheme: {
+    library: {
+        sources: [
+            {
+                id: "flowforge-team-library",
+                type: "flowforge-team-library",
+                label: "Team Library",
+                icon: "font-awesome/fa-users",
+                baseURL: '${settings.storageURL}',
+                projectID: '${settings.projectID}',
+                libraryID: '${settings.teamID}',
+                token: '${settings.projectToken}'
+            }
+        ]
+    }
+}
+```

--- a/library.js
+++ b/library.js
@@ -1,0 +1,87 @@
+const got = require('got')
+
+module.exports = function (RED) {
+    const PLUGIN_TYPE_ID = 'flowforge-team-library'
+
+    class FFTeamLibraryPlugin {
+        constructor (config) {
+            this.type = PLUGIN_TYPE_ID
+            this.id = config.id
+            this.label = config.label
+            const { projectID, libraryID, token } = config
+            if (!projectID) {
+                throw new Error('Missing required configuration property: projectID')
+            }
+            if (!libraryID) {
+                throw new Error('Missing required configuration property: libraryID')
+            }
+            if (!token) {
+                throw new Error('Missing required configuration property: token')
+            }
+            console.log(config.baseURL + '/' + projectID + '/shared-library/' + libraryID + '/')
+            this._client = got.extend({
+                prefixUrl: config.baseURL + '/' + projectID + '/shared-library/' + libraryID + '/',
+                headers: {
+                    'user-agent': 'FlowForge HTTP Storage v0.1',
+                    authorization: 'Bearer ' + token
+                },
+                timeout: {
+                    request: 10000
+                }
+            })
+        }
+
+        /**
+         * Initialise the store.
+         */
+        async init () {
+        }
+
+        /**
+         * Get an entry from the store
+         * @param {string} type The type of entry, for example, "flow"
+         * @param {string} path The path to the library entry
+         * @return if 'path' resolves to a single entry, it returns the contents
+         *         of that entry.
+         *         if 'path' resolves to a 'directory', it returns a listing of
+         *         the contents of the directory
+         *         if 'path' is not valid, it should throw a suitable error
+         */
+        async getEntry (type, name) {
+            return this._client.get(type, {
+                searchParams: {
+                    name
+                }
+            }).then(entry => {
+                if (entry.headers['content-type'].startsWith('application/json')) {
+                    return JSON.parse(entry.body)
+                } else {
+                    return entry.body
+                }
+            })
+        }
+
+        /**
+         * Save an entry to the library
+         * @param {string} type The type of entry, for example, "flow"
+         * @param {string} path The path to the library entry
+         * @param {object} meta An object of key/value meta data about the entry
+         * @param {string} body The entry contents
+         */
+        async saveEntry (type, name, meta, body) {
+            return this._client.post(type, {
+                json: {
+                    name,
+                    meta,
+                    body
+                },
+                responseType: 'json'
+            })
+        }
+    }
+
+    RED.plugins.registerPlugin(PLUGIN_TYPE_ID, {
+        type: 'node-red-library-source',
+        class: FFTeamLibraryPlugin
+    })
+}

--- a/library.js
+++ b/library.js
@@ -18,7 +18,6 @@ module.exports = function (RED) {
             if (!token) {
                 throw new Error('Missing required configuration property: token')
             }
-            console.log(config.baseURL + '/' + projectID + '/shared-library/' + libraryID + '/')
             this._client = got.extend({
                 prefixUrl: config.baseURL + '/' + projectID + '/shared-library/' + libraryID + '/',
                 headers: {

--- a/package.json
+++ b/package.json
@@ -30,5 +30,10 @@
     "devDependencies": {
         "eslint": "^8.25.0",
         "eslint-config-standard": "^17.0.0"
+    },
+    "node-red": {
+        "plugins": {
+            "teamLibrary": "library.js"
+        }
     }
 }


### PR DESCRIPTION
## Description

Adds a Library Store plugin for Node-RED that is used to access a shared Team Library.

The code is largely a copy of the Storage Module's handling of the 'local' library - just updated for the shared library API route.

## Related Issue(s)

Part of:
 - https://github.com/flowforge/flowforge/issues/237

Related PRs:
 - https://github.com/flowforge/flowforge-nr-launcher/pull/93 - add the required library config to `settings.js`
 - https://github.com/flowforge/flowforge/pull/1529 - to add the Storage API routes

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

