### PR TITLE
Update shared library api to match revised platform API

### DIFF
--- a/library.js
+++ b/library.js
@@ -19,7 +19,7 @@ module.exports = function (RED) {
                 throw new Error('Missing required configuration property: token')
             }
             this._client = got.extend({
-                prefixUrl: config.baseURL + '/' + projectID + '/shared-library/' + libraryID + '/',
+                prefixUrl: config.baseURL + '/library/' + libraryID + '/',
                 headers: {
                     'user-agent': 'FlowForge HTTP Storage v0.1',
                     authorization: 'Bearer ' + token
@@ -47,9 +47,9 @@ module.exports = function (RED) {
          *         if 'path' is not valid, it should throw a suitable error
          */
         async getEntry (type, name) {
-            return this._client.get(type, {
+            return this._client.get(name, {
                 searchParams: {
-                    name
+                    type
                 }
             }).then(entry => {
                 if (entry.headers['content-type'].startsWith('application/json')) {
@@ -68,9 +68,10 @@ module.exports = function (RED) {
          * @param {string} body The entry contents
          */
         async saveEntry (type, name, meta, body) {
-            return this._client.post(type, {
+            return this._client.post(name, {
                 json: {
                     name,
+                    type,
                     meta,
                     body
                 },


### PR DESCRIPTION
## Description

This updates the storage plugin to use the revised shared library API introduced by #1572.

This makes for a cleaner API implementation.

I've only modified the newly added shared library api. We should consider revising the existing 'local' library api to match, but the serve side would have to maintain support for old and new as projects may not update immediately.


## Related Issue(s)

 - https://github.com/flowforge/flowforge/pull/1572

